### PR TITLE
Add a `mule_file` method to the Python API

### DIFF
--- a/plugins/python/uwsgi_pymodule.c
+++ b/plugins/python/uwsgi_pymodule.c
@@ -1488,6 +1488,27 @@ PyObject *py_uwsgi_mule_get_msg(PyObject * self, PyObject * args, PyObject *kwar
 	return msg;
 }
 
+PyObject *py_uwsgi_mule_file(PyObject * self, PyObject * args) {
+	
+	int mule_id = uwsgi.muleid;
+
+	if (PyArg_ParseTuple(args, "|i", &mule_id) && mule_id == 0) {
+		return NULL;
+	}
+
+	if (uwsgi.mules_cnt < mule_id && mule_id > 0) {
+		return PyErr_Format(PyExc_ValueError, "The id you provided doesn't correspond to any mule");
+	}
+
+	struct uwsgi_mule *mule = get_mule_by_id(mule_id);
+	if (!mule || !mule->patch) {
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
+	return PyString_FromString(mule->patch);
+}
+
 PyObject *py_uwsgi_farm_get_msg(PyObject * self, PyObject * args) {
 
         ssize_t len = 0;
@@ -2814,6 +2835,8 @@ static PyMethodDef uwsgi_advanced_methods[] = {
 	{"add_var", py_uwsgi_add_var, METH_VARARGS, ""},
 
 	{"micros", py_uwsgi_micros, METH_VARARGS, ""},
+
+	{"mule_file", py_uwsgi_mule_file, METH_VARARGS, ""},
 
 	{NULL, NULL},
 };


### PR DESCRIPTION
This method adds a new biddings in the `uwsgi` Python module, named `mule_file`, which return the file which the mule was loaded with, or `None` if the mule doesn't have any logic.